### PR TITLE
the totalVotes forced to update

### DIFF
--- a/lib/flutter_polls.dart
+++ b/lib/flutter_polls.dart
@@ -222,10 +222,12 @@ class FlutterPolls extends HookWidget {
             )
             .toList()
             .first);
+    final myTotalVotes = pollOptions.fold(0, (acc, option) => acc + option.votes,);
     final totalVotes = useState<int>(pollOptions.fold(
       0,
-      (acc, option) => acc + option.votes,
+          (acc, option) => acc + option.votes,
     ));
+    totalVotes.value = myTotalVotes;
 
     return Column(
       key: ValueKey(pollId),


### PR DESCRIPTION
the underlying totalVotes weren't updating when polloptions changed causing a problem when dividing and failing at the percentage. This fixes it.

For example: polloptions filled from firebase stream. stream adds 100 votes, polloptions DO update, "totalVotes" doesn't.